### PR TITLE
fix: avoid panic when got "mp3: free bitrate format is not supported.…" error

### DIFF
--- a/mp3/decode.go
+++ b/mp3/decode.go
@@ -31,6 +31,9 @@ func (p *decoded) BytesPerSample() int {
 func Decode(r io.ReadSeeker) (audio.Decoded, error) {
 	b := bufiox.NewReader(r)
 	dec, err := mp3.NewDecoder(b)
+	if err != nil {
+		return nil, err
+	}
 	return &decoded{Decoder: *dec}, err
 }
 


### PR DESCRIPTION
fix: avoid panic when got "mp3: free bitrate format is not supported. Header word is 0xffff0200 at position 97666" error